### PR TITLE
Fix localization, thread safety, and dependencies

### DIFF
--- a/duels-plugin/build.gradle
+++ b/duels-plugin/build.gradle
@@ -22,9 +22,7 @@ dependencies {
     implementation 'com.mojang:authlib:1.5.25'
     implementation 'me.clip:placeholderapi:2.11.6'
     // These are compileOnly because runtime presence is provided by the server classpath
-    compileOnly 'com.github.sirblobman.api:core:2.9-SNAPSHOT'
     implementation 'com.github.timderspieler:DeluxeCombat-API:1.5.1'
-    compileOnly 'com.github.sirblobman.combatlogx:api:11.5-SNAPSHOT'
     implementation 'com.artillexstudios:AxGraves:1.7.0'
     implementation 'com.github.No-Not-Jaden:NotBounties:1.22.0'
     implementation('net.essentialsx:EssentialsX:2.21.2') {


### PR DESCRIPTION
Refactor `RankManager` for thread-safe Bukkit API usage and remove unused dependencies.

The `RankManager` previously made `Bukkit.getPlayer()` calls and mutated non-thread-safe collections off the main thread, leading to potential runtime errors. This PR moves `Player` lookups to the main thread via the scheduler and uses `ConcurrentHashMap.newKeySet()` for atomic reward claiming, preventing race conditions and ensuring proper Bukkit API interaction. Unused snapshot dependencies were also removed for project cleanup.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba36e968-b2c7-4da4-882c-593475bdf744">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba36e968-b2c7-4da4-882c-593475bdf744">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

