### PR TITLE
Replace gui and inventory with triumph gui

### DIFF
--- a/duels-plugin/build.gradle
+++ b/duels-plugin/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	implementation 'co.aikar:acf-paper:0.5.1-SNAPSHOT'
 	implementation 'org.reflections:reflections:0.10.2'
     implementation 'org.javassist:javassist:3.30.2-GA'
+
+    // Triumph GUI
+    implementation 'dev.triumphteam:triumph-gui:3.1.12'
 }
 
 repositories {
@@ -72,6 +75,7 @@ shadowJar {
 		include(dependency('org.reflections:.*'))
 		include(dependency('org.javassist:.*'))
 		include(dependency('com.google.inject:.*'))
+        include(dependency('dev.triumphteam:triumph-gui:.*'))
 	}
 
 	final String group = project.group.toString() + "." + parent.name.toLowerCase() + ".shaded."
@@ -88,6 +92,7 @@ shadowJar {
 	relocate 'org.reflections', group + 'reflections'
 	relocate 'javassist', group + 'javassist'
 	relocate 'com.google.inject', group + 'guice'
+    relocate 'dev.triumphteam.gui', group + 'triumph.gui'
 }
 
 // To build Duels plugin jar, run './gradlew clean build'.

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/commands/KitCommand.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/commands/KitCommand.java
@@ -18,75 +18,75 @@ import org.bukkit.inventory.ItemStack;
 @CommandPermission("duels.admin")
 public class KitCommand extends BaseCommand {
 
-    public KitCommand(DuelsPlugin plugin) {
-        super(plugin);
-    }
+	public KitCommand(DuelsPlugin plugin) {
+		super(plugin);
+	}
 
-    @Subcommand("savekit")
-    @CommandCompletion("@nothing")
-    @Description("Saves a kit with given name.")
-    public void onSaveKit(Player player, String name, @Optional String override) {
-        if (!StringUtil.isAlphanumeric(name)) {
-            lang.sendMessage(player, "ERROR.command.name-not-alphanumeric", "name", name);
-            return;
-        }
+	@Subcommand("savekit")
+	@CommandCompletion("@nothing")
+	@Description("Saves a kit with given name.")
+	public void onSaveKit(Player player, String name, @Optional String override) {
+		if (!StringUtil.isAlphanumeric(name)) {
+			lang.sendMessage(player, "ERROR.command.name-not-alphanumeric", "name", name);
+			return;
+		}
 
-        if (kitManager.create(player, name, override != null && override.equals("-o")) == null) {
-            lang.sendMessage(player, "ERROR.kit.already-exists", "name", name);
-            return;
-        }
+		if (kitManager.create(player, name, override != null && override.equals("-o")) == null) {
+			lang.sendMessage(player, "ERROR.kit.already-exists", "name", name);
+			return;
+		}
 
-        lang.sendMessage(player, "COMMAND.duels.save-kit", "name", name);
-    }
+		lang.sendMessage(player, "COMMAND.duels.save-kit", "name", name);
+	}
 
-    @Subcommand("loadkit")
-    @CommandCompletion("@kits")
-    @Description("Loads the selected kit to your inventory.")
-    public void onLoadKit(Player player, KitImpl kit) {
-        player.getInventory().clear();
-        kit.equip(player);
-        lang.sendMessage(player, "COMMAND.duels.load-kit", "name", kit.getName());
-    }
+	@Subcommand("loadkit")
+	@CommandCompletion("@kits")
+	@Description("Loads the selected kit to your inventory.")
+	public void onLoadKit(Player player, KitImpl kit) {
+		player.getInventory().clear();
+		kit.equip(player);
+		lang.sendMessage(player, "COMMAND.duels.load-kit", "name", kit.getName());
+	}
 
-    @Subcommand("deletekit")
-    @CommandCompletion("@kits")
-    @Description("Deletes a kit.")
-    public void onDeleteKit(CommandSender sender, KitImpl kit) {
-        if (kitManager.remove(sender, kit.getName()) == null) {
-            lang.sendMessage(sender, "ERROR.kit.not-found", "name", kit.getName());
-            return;
-        }
+	@Subcommand("deletekit")
+	@CommandCompletion("@kits")
+	@Description("Deletes a kit.")
+	public void onDeleteKit(CommandSender sender, KitImpl kit) {
+		if (kitManager.remove(sender, kit.getName()) == null) {
+			lang.sendMessage(sender, "ERROR.kit.not-found", "name", kit.getName());
+			return;
+		}
 
-        lang.sendMessage(sender, "COMMAND.duels.delete-kit", "name", kit.getName());
-    }
+		lang.sendMessage(sender, "COMMAND.duels.delete-kit", "name", kit.getName());
+	}
 
-    @Subcommand("setitem")
-    @CommandCompletion("@kits")
-    @Description("Sets the displayed item for selected kit.")
-    public void onSetItem(Player player, KitImpl kit) {
-        final ItemStack held = InventoryUtil.getItemInHand(player);
+	@Subcommand("setitem")
+	@CommandCompletion("@kits")
+	@Description("Sets the displayed item for selected kit.")
+	public void onSetItem(Player player, KitImpl kit) {
+		final ItemStack held = InventoryUtil.getItemInHand(player);
 
-        if (held == null || held.getType() == Material.AIR) {
-            lang.sendMessage(player, "ERROR.kit.empty-hand");
-            return;
-        }
+		if (held == null || held.getType() == Material.AIR) {
+			lang.sendMessage(player, "ERROR.kit.empty-hand");
+			return;
+		}
 
-        kit.setDisplayed(held.clone());
-        kitManager.getGui().calculatePages();
-        lang.sendMessage(player, "COMMAND.duels.set-item", "name", kit.getName());
-    }
+		kit.setDisplayed(held.clone());
+		kitManager.getGui().calculatePages();
+		lang.sendMessage(player, "COMMAND.duels.set-item", "name", kit.getName());
+	}
 
-    @Subcommand("options")
-    @CommandCompletion("@kits")
-    @Description("Opens the options gui for kit.")
-    public void onOptions(Player player, KitImpl kit) {
-        plugin.getGuiListener().addGui(player, new OptionsGui(plugin, player, kit), true).open(player);
-    }
+	@Subcommand("options")
+	@CommandCompletion("@kits")
+	@Description("Opens the options gui for kit.")
+	public void onOptions(Player player, KitImpl kit) {
+		new OptionsGui(plugin, player, kit).open(player);
+	}
 
-    @Subcommand("bind")
-    @CommandCompletion("@kits")
-    @Description("Opens the arena bind gui for kit.")
-    public void onBind(Player player, KitImpl kit) {
-        plugin.getGuiListener().addGui(player, new BindGui(plugin, kit), true).open(player);
-    }
+	@Subcommand("bind")
+	@CommandCompletion("@kits")
+	@Description("Opens the arena bind gui for kit.")
+	public void onBind(Player player, KitImpl kit) {
+		new BindGui(plugin, kit).open(player);
+	}
 }

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/gui/bind/BindGui.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/gui/bind/BindGui.java
@@ -6,26 +6,57 @@ import com.emmerichbrowne.duels.config.Lang;
 import com.emmerichbrowne.duels.gui.bind.buttons.BindButton;
 import com.emmerichbrowne.duels.kit.KitImpl;
 import com.emmerichbrowne.duels.util.CommonItems;
-import com.emmerichbrowne.duels.util.gui.MultiPageGui;
 import com.emmerichbrowne.duels.util.inventory.ItemBuilder;
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.PaginatedGui;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 
-import java.util.stream.Collectors;
+public class BindGui {
 
-public class BindGui extends MultiPageGui<DuelsPlugin> {
+	private final PaginatedGui gui;
+	private final DuelsPlugin plugin;
+	private final KitImpl kit;
 
-    public BindGui(final DuelsPlugin plugin, final KitImpl kit) {
-        super(plugin, plugin.getLang().getMessage("GUI.options.bind.title", "kit", kit.getName()), plugin.getConfiguration().getArenaSelectorRows(),
-                plugin.getArenaManager().getArenasImpl().stream().map(arena -> new BindButton(plugin, kit, arena)).collect(Collectors.toList()));
+	public BindGui(final DuelsPlugin plugin, final KitImpl kit) {
+		this.plugin = plugin;
+		this.kit = kit;
+		final int rows = plugin.getConfiguration().getArenaSelectorRows();
+		this.gui = new PaginatedGui(rows, 9, LegacyComponentSerializer.legacySection().deserialize(plugin.getLang().getMessage("GUI.options.bind.title", "kit", kit.getName())));
 
-        final Config config = plugin.getConfiguration();
-        final Lang lang = plugin.getLang();
-        setSpaceFiller(CommonItems.from(config.getArenaSelectorFillerType()));
-        setPrevButton(ItemBuilder.of(Material.PAPER).name(lang.getMessage("GUI.arena-selector.buttons.previous-page.name")).build());
-        setNextButton(ItemBuilder.of(Material.PAPER).name(lang.getMessage("GUI.arena-selector.buttons.next-page.name")).build());
-        setEmptyIndicator(ItemBuilder.of(Material.PAPER).name(lang.getMessage("GUI.arena-selector.buttons.empty.name")).build());
-        // Change design to remove this loop in the future
-        getButtons().forEach(button -> ((BindButton) button).setGui(this));
-        calculatePages();
-    }
+		this.gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+		final Config config = plugin.getConfiguration();
+		final Lang lang = plugin.getLang();
+
+		// Fill background with filler
+		final org.bukkit.inventory.ItemStack filler = CommonItems.from(config.getArenaSelectorFillerType());
+		this.gui.getFiller().fill(ItemBuilder.from(filler).asGuiItem());
+
+		// Prev/next buttons
+		final org.bukkit.inventory.ItemStack prev = ItemBuilder.from(ItemBuilder.of(Material.PAPER).name(lang.getMessage("GUI.arena-selector.buttons.previous-page.name")).build()).build();
+		final org.bukkit.inventory.ItemStack next = ItemBuilder.from(ItemBuilder.of(Material.PAPER).name(lang.getMessage("GUI.arena-selector.buttons.next-page.name")).build()).build();
+		this.gui.setItem(rows, 3, ItemBuilder.from(prev).asGuiItem(e -> gui.previous()))
+				.setItem(rows, 7, ItemBuilder.from(next).asGuiItem(e -> gui.next()));
+
+		rebuildItems();
+	}
+
+	private void rebuildItems() {
+		gui.clearPageItems();
+		plugin.getArenaManager().getArenasImpl().stream()
+				.map(arena -> new BindButton(plugin, kit, arena))
+				.peek(button -> button.setGui(this))
+				.map(button -> ItemBuilder.from(button.getDisplayed().clone()).asGuiItem(e -> button.onClick((Player) e.getWhoClicked())))
+				.forEach(gui::addItem);
+	}
+
+	public void open(Player player) {
+		gui.open(player);
+	}
+
+	public void calculatePages() {
+		rebuildItems();
+	}
 }

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/gui/options/buttons/OptionButton.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/gui/options/buttons/OptionButton.java
@@ -14,38 +14,42 @@ import java.util.List;
 
 public class OptionButton extends BaseButton {
 
-    private final OptionsGui gui;
-    private final KitImpl kit;
-    private final Option option;
+	private final OptionsGui gui;
+	private final KitImpl kit;
+	private final Option option;
 
-    public OptionButton(final DuelsPlugin plugin, final OptionsGui gui, final KitImpl kit, final Option option) {
-        super(plugin, ItemBuilder.of(option.getDisplayed()).build());
-        this.gui = gui;
-        this.kit = kit;
-        this.option = option;
-        setDisplayName(plugin.getLang().getMessage("GUI.options.buttons.option.name", "name", option.name().toLowerCase()));
-        update();
-    }
+	public OptionButton(final DuelsPlugin plugin, final OptionsGui gui, final KitImpl kit, final Option option) {
+		super(plugin, ItemBuilder.of(option.getDisplayed()).build());
+		this.gui = gui;
+		this.kit = kit;
+		this.option = option;
+		setDisplayName(plugin.getLang().getMessage("GUI.options.buttons.option.name", "name", option.name().toLowerCase()));
+		update();
+	}
 
-    private void update() {
-        final boolean state = option.get(kit);
-        setGlow(state);
+	public Option getOption() {
+		return option;
+	}
 
-        final List<String> lore = new ArrayList<>();
+	private void update() {
+		final boolean state = option.get(kit);
+		setGlow(state);
 
-        for (final String line : option.getDescription()) {
-            lore.add("&f" + line.replace("%kit%", kit.getName()));
-        }
+		final List<String> lore = new ArrayList<>();
 
-        Collections.addAll(lore,
-                lang.getMessage("GUI.options.buttons.option.lore", "state", state ? lang.getMessage("GENERAL.enabled") : lang.getMessage("GENERAL.disabled")).split("\n"));
-        setLore(lore);
-    }
+		for (final String line : option.getDescription()) {
+			lore.add("&f" + line.replace("%kit%", kit.getName()));
+		}
 
-    @Override
-    public void onClick(final Player player) {
-        option.set(kit);
-        update();
-        gui.update(player, this);
-    }
+		Collections.addAll(lore,
+				lang.getMessage("GUI.options.buttons.option.lore", "state", state ? lang.getMessage("GENERAL.enabled") : lang.getMessage("GENERAL.disabled")).split("\n"));
+		setLore(lore);
+	}
+
+	@Override
+	public void onClick(final Player player) {
+		option.set(kit);
+		update();
+		gui.update(player, this);
+	}
 }

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/gui/settings/SettingsGui.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/gui/settings/SettingsGui.java
@@ -5,58 +5,113 @@ import com.emmerichbrowne.duels.config.Config;
 import com.emmerichbrowne.duels.gui.BaseButton;
 import com.emmerichbrowne.duels.gui.settings.buttons.*;
 import com.emmerichbrowne.duels.util.CommonItems;
-import com.emmerichbrowne.duels.util.gui.SinglePageGui;
-import com.emmerichbrowne.duels.util.inventory.Slots;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class SettingsGui extends SinglePageGui<DuelsPlugin> {
+public class SettingsGui {
 
-    private static final int[][] PATTERNS = {
-            {13},
-            {12, 14},
-            {12, 13, 14},
-            {12, 13, 14, 22}
-    };
+	private static final int[][] PATTERNS = {
+				{13},
+				{12, 14},
+				{12, 13, 14},
+				{12, 13, 14, 22}
+	};
 
-    public SettingsGui(final DuelsPlugin plugin) {
-        super(plugin, plugin.getLang().getMessage("GUI.settings.title"), 3);
-        final Config config = plugin.getConfiguration();
-        final ItemStack spacing = CommonItems.from(config.getSettingsFillerType());
-        Slots.run(2, 7, slot -> inventory.setItem(slot, spacing));
-        Slots.run(11, 16, slot -> inventory.setItem(slot, spacing));
-        Slots.run(20, 25, slot -> inventory.setItem(slot, spacing));
-        set(4, new RequestDetailsButton(plugin));
+	private final DuelsPlugin plugin;
+	private final Gui gui;
 
-        final List<BaseButton> buttons = new ArrayList<>();
+	public SettingsGui(final DuelsPlugin plugin) {
+		this.plugin = plugin;
+		this.gui = Gui.gui()
+				.title(LegacyComponentSerializer.legacySection().deserialize(plugin.getLang().getMessage("GUI.settings.title")))
+				.rows(3)
+				.create();
 
-        if (config.isKitSelectingEnabled()) {
-            buttons.add(new KitSelectButton(plugin));
-        }
+		// Cancel all clicks by default
+		this.gui.setDefaultClickAction(event -> event.setCancelled(true));
+	}
 
-        if (config.isOwnInventoryEnabled()) {
-            buttons.add(new OwnInventoryButton(plugin));
-        }
+	public void open(final Player player) {
+		populate(player);
+		gui.open(player);
+	}
 
-        if (config.isArenaSelectingEnabled()) {
-            buttons.add(new ArenaSelectButton(plugin));
-        }
+	public void update(final Player player) {
+		populate(player);
+	}
 
-        if (config.isItemBettingEnabled()) {
-            buttons.add(new ItemBettingButton(plugin));
-        }
+	private void populate(final Player player) {
+		final Config config = plugin.getConfiguration();
+		final ItemStack spacing = CommonItems.from(config.getSettingsFillerType());
 
-        if (!buttons.isEmpty()) {
-            final int[] pattern = PATTERNS[buttons.size() - 1];
+		// Clear and fill background spacers in the same slots as before
+		gui.getInventory().clear();
+		fillRange(2, 7, 0, spacing);
+		fillRange(11, 16, 0, spacing);
+		fillRange(20, 25, 0, spacing);
 
-            for (int i = 0; i < buttons.size(); i++) {
-                set(pattern[i], buttons.get(i));
-            }
-        }
+		// Center head/details button
+		setButton(4, new RequestDetailsButton(plugin), player);
 
-        set(0, 2, 3, new RequestSendButton(plugin));
-        set(7, 9, 3, new CancelButton(plugin));
-    }
+		final List<BaseButton> buttons = new ArrayList<>();
+
+		if (config.isKitSelectingEnabled()) {
+			buttons.add(new KitSelectButton(plugin));
+		}
+
+		if (config.isOwnInventoryEnabled()) {
+			buttons.add(new OwnInventoryButton(plugin));
+		}
+
+		if (config.isArenaSelectingEnabled()) {
+			buttons.add(new ArenaSelectButton(plugin));
+		}
+
+		if (config.isItemBettingEnabled()) {
+			buttons.add(new ItemBettingButton(plugin));
+		}
+
+		if (!buttons.isEmpty()) {
+			final int[] pattern = PATTERNS[buttons.size() - 1];
+			for (int i = 0; i < buttons.size(); i++) {
+				setButton(pattern[i], buttons.get(i), player);
+			}
+		}
+
+		// Action bars (left: send; right: cancel) across 3 rows like before
+		setButtonRange(0, 2, 3, new RequestSendButton(plugin), player);
+		setButtonRange(7, 9, 3, new CancelButton(plugin), player);
+	}
+
+	private void setButton(final int slot, final BaseButton button, final Player player) {
+		button.update(player);
+		final ItemStack displayed = button.getDisplayed().clone();
+		final GuiItem item = new GuiItem(displayed, event -> button.onClick(player));
+		gui.setItem(slot, item);
+	}
+
+	private void setButtonRange(final int from, final int to, final int height, final BaseButton button, final Player player) {
+		button.update(player);
+		final ItemStack displayed = button.getDisplayed().clone();
+		final GuiItem item = new GuiItem(displayed, event -> button.onClick(player));
+		for (int h = 0; h < height; h++) {
+			for (int s = from; s < to; s++) {
+				gui.setItem(s + h * 9, item);
+			}
+		}
+	}
+
+	private void fillRange(final int from, final int to, final int height, final ItemStack item) {
+		for (int h = 0; h < height + 1; h++) {
+			for (int s = from; s < to; s++) {
+				gui.setItem(s + h * 9, new GuiItem(item.clone(), e -> e.setCancelled(true)));
+			}
+		}
+	}
 }

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/setting/Settings.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/setting/Settings.java
@@ -16,135 +16,137 @@ import java.util.UUID;
 
 public class Settings {
 
-    private final DuelsPlugin plugin;
-    private final SettingsGui gui;
+	private final DuelsPlugin plugin;
+	private final SettingsGui gui;
 
-    @Getter
-    private UUID target;
-    @Getter
-    private KitImpl kit;
-    @Getter
-    @Setter
-    private ArenaImpl arena;
-    @Getter
-    @Setter
-    private int bet;
-    @Getter
-    @Setter
-    private boolean itemBetting;
-    @Getter
-    private boolean ownInventory;
-    @Getter
-    private Map<UUID, CachedInfo> cache = new HashMap<>();
-    @Getter
-    @Setter
-    private Party senderParty;
-    @Getter
-    @Setter
-    private Party targetParty;
+	@Getter
+	private UUID target;
+	@Getter
+	private KitImpl kit;
+	@Getter
+	@Setter
+	private ArenaImpl arena;
+	@Getter
+	@Setter
+	private int bet;
+	@Getter
+	@Setter
+	private boolean itemBetting;
+	@Getter
+	private boolean ownInventory;
+	@Getter
+	private Map<UUID, CachedInfo> cache = new HashMap<>();
+	@Getter
+	@Setter
+	private Party senderParty;
+	@Getter
+	@Setter
+	private Party targetParty;
 
-    public Settings(final DuelsPlugin plugin, final Player player) {
-        this.plugin = plugin;
-        this.gui = player != null ? plugin.getGuiListener().addGui(player, new SettingsGui(plugin)) : null;
-        // If kits are disabled, then ownInventory is enabled by default.
-        this.ownInventory = !plugin.getConfiguration().isKitSelectingEnabled();
-    }
+	public Settings(final DuelsPlugin plugin, final Player player) {
+		this.plugin = plugin;
+		this.gui = player != null ? new SettingsGui(plugin) : null;
+		// If kits are disabled, then ownInventory is enabled by default.
+		this.ownInventory = !plugin.getConfiguration().isKitSelectingEnabled();
+	}
 
-    public Settings(final DuelsPlugin plugin) {
-        this(plugin, null);
-    }
+	public Settings(final DuelsPlugin plugin) {
+		this(plugin, null);
+	}
 
-    public void reset() {
-        target = null;
-        senderParty = null;
-        targetParty = null;
-        kit = null;
-        arena = null;
-        bet = 0;
-        itemBetting = false;
-        ownInventory = !plugin.getConfiguration().isKitSelectingEnabled();
-        clearCache();
-    }
+	public void reset() {
+		target = null;
+		senderParty = null;
+		targetParty = null;
+		kit = null;
+		arena = null;
+		bet = 0;
+		itemBetting = false;
+		ownInventory = !plugin.getConfiguration().isKitSelectingEnabled();
+		clearCache();
+	}
 
-    public void setTarget(final Player target) {
-        if (this.target != null && !this.target.equals(target.getUniqueId())) {
-            reset();
-        }
+	public void setTarget(final Player target) {
+		if (this.target != null && !this.target.equals(target.getUniqueId())) {
+			reset();
+		}
 
-        this.target = target.getUniqueId();
-    }
+		this.target = target.getUniqueId();
+	}
 
-    public void updateGui(final Player player) {
-        if (gui != null) {
-            gui.update(player);
-        }
-    }
+	public void updateGui(final Player player) {
+		if (gui != null) {
+			gui.update(player);
+		}
+	}
 
-    public void clearCache() {
-        cache.clear();
-    }
+	public void clearCache() {
+		cache.clear();
+	}
 
-    public void openGui(final Player player) {
-        gui.open(player);
-    }
+	public void openGui(final Player player) {
+		if (gui != null) {
+			gui.open(player);
+		}
+	}
 
-    public void setBaseLoc(final Player player) {
-        cache.computeIfAbsent(player.getUniqueId(), result -> new CachedInfo()).setLocation(player.getLocation().clone());
-    }
+	public void setBaseLoc(final Player player) {
+		cache.computeIfAbsent(player.getUniqueId(), result -> new CachedInfo()).setLocation(player.getLocation().clone());
+	}
 
-    public Location getBaseLoc(final Player player) {
-        final CachedInfo info = cache.get(player.getUniqueId());
+	public Location getBaseLoc(final Player player) {
+		final CachedInfo info = cache.get(player.getUniqueId());
 
-        if (info == null) {
-            return null;
-        }
+		if (info == null) {
+			return null;
+		}
 
-        return info.getLocation();
-    }
+		return info.getLocation();
+	}
 
-    public void setDuelzone(final Player player, final String duelzone) {
-        cache.computeIfAbsent(player.getUniqueId(), result -> new CachedInfo()).setDuelzone(duelzone);
-    }
+	public void setDuelzone(final Player player, final String duelzone) {
+		cache.computeIfAbsent(player.getUniqueId(), result -> new CachedInfo()).setDuelzone(duelzone);
+	}
 
-    public String getDuelzone(final Player player) {
-        final CachedInfo info = cache.get(player.getUniqueId());
+	public String getDuelzone(final Player player) {
+		final CachedInfo info = cache.get(player.getUniqueId());
 
-        if (info == null) {
-            return null;
-        }
+		if (info == null) {
+			return null;
+		}
 
-        return info.getDuelzone();
-    }
+		return info.getDuelzone();
+	}
 
-    public boolean isPartyDuel() {
-        return senderParty != null && targetParty != null;
-    }
+	public boolean isPartyDuel() {
+		return senderParty != null && targetParty != null;
+	}
 
-    public void setKit(final KitImpl kit) {
-        this.kit = kit;
-        this.ownInventory = false;
-    }
+	public void setKit(final KitImpl kit) {
+		this.kit = kit;
+		this.ownInventory = false;
+	}
 
-    public void setOwnInventory(final boolean ownInventory) {
-        this.ownInventory = ownInventory;
+	public void setOwnInventory(final boolean ownInventory) {
+		this.ownInventory = ownInventory;
 
-        if (ownInventory) {
-            this.kit = null;
-        }
-    }
+		if (ownInventory) {
+			this.kit = null;
+		}
+	}
 
-    // Don't copy the gui since it won't be required to start a match
-    public Settings lightCopy() {
-        final Settings copy = new Settings(plugin);
-        copy.target = target;
-        copy.senderParty = senderParty;
-        copy.targetParty = targetParty;
-        copy.kit = kit;
-        copy.arena = arena;
-        copy.bet = bet;
-        copy.itemBetting = itemBetting;
-        copy.ownInventory = ownInventory;
-        copy.cache = new HashMap<>(cache);
-        return copy;
-    }
+	// Don't copy the gui since it won't be required to start a match
+	public Settings lightCopy() {
+		final Settings copy = new Settings(plugin);
+		copy.target = target;
+		copy.senderParty = senderParty;
+		copy.targetParty = targetParty;
+		copy.kit = kit;
+		copy.arena = arena;
+		copy.bet = bet;
+		copy.itemBetting = itemBetting;
+		copy.ownInventory = ownInventory;
+		copy.cache = new HashMap<>(cache);
+		return copy;
+	}
 }


### PR DESCRIPTION
Migrate `SettingsGui`, `OptionsGui`, and `BindGui` to Triumph GUI as the first step in replacing the legacy GUI system.

This PR sets up the Triumph GUI dependency and refactors the initial set of GUI classes (`SettingsGui`, `OptionsGui`, `BindGui`) to use the new library, updating their respective command usages. This is part of a larger effort to completely replace the old `util.gui` framework.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7c4ec06-9a8b-494f-a6be-b375b927a82b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7c4ec06-9a8b-494f-a6be-b375b927a82b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

