### PR TITLE
Separate game logic into dedicated plugin

### DIFF
--- a/duels-core/build.gradle
+++ b/duels-core/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation project(':duels-api')
+}
+

--- a/duels-core/src/main/java/com/emmerichbrowne/duels/core/ServerRole.java
+++ b/duels-core/src/main/java/com/emmerichbrowne/duels/core/ServerRole.java
@@ -1,0 +1,7 @@
+package com.emmerichbrowne.duels.core;
+
+public enum ServerRole {
+	LOBBY,
+	GAME
+}
+

--- a/duels-game-plugin/build.gradle
+++ b/duels-game-plugin/build.gradle
@@ -2,34 +2,78 @@ apply plugin: 'com.gradleup.shadow'
 
 processResources {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    from(sourceSets.main.resources.srcDirs) {
+        include '**/*.yml'
+        filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [VERSION: project.version])
+    }
 }
 
 dependencies {
     implementation project(':duels-api')
+    implementation project(':duels-plugin')
 
     compileOnly 'org.projectlombok:lombok:1.18.38'
     annotationProcessor 'org.projectlombok:lombok:1.18.38'
 
     implementation 'space.arim.morepaperlib:morepaperlib:0.4.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.19.2'
+    implementation 'org.mongodb:mongodb-driver-sync:5.1.2'
+    implementation 'redis.clients:jedis:5.1.5'
+    implementation 'org.apache.commons:commons-pool2:2.12.0'
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
+    implementation 'net.kyori:adventure-text-serializer-ansi:4.17.0'
+    implementation 'co.aikar:acf-paper:0.5.1-SNAPSHOT'
+    implementation 'org.reflections:reflections:0.10.2'
+    implementation 'org.javassist:javassist:3.30.2-GA'
+    implementation 'dev.triumphteam:triumph-gui:3.1.12'
+
+    compileOnly 'com.sk89q.worldguard:worldguard-bukkit:7.0.14'
 }
 
 repositories {
     mavenCentral()
+    maven { url 'https://repo.aikar.co/content/groups/aikar/' }
 }
 
 shadowJar {
     getDestinationDirectory().set(file("$rootDir/out/"))
 
-    final String archiveName = parent.name + '-' + project.version + '.jar'
+    final String archiveName = 'Duels-Game-' + project.version + '.jar'
     getArchiveFileName().set(archiveName)
 
     dependencies {
         include(project(':duels-api'))
+        include(project(':duels-plugin'))
+        include(dependency('com.fasterxml.jackson.core:.*'))
         include(dependency('space.arim.morepaperlib:.*'))
+        include(dependency('org.mongodb:.*'))
+        include(dependency('redis.clients:.*'))
+        include(dependency('org.apache.commons:commons-pool2:.*'))
+        include(dependency('org.apache.commons:commons-lang3:.*'))
+        include(dependency('net.kyori:adventure-text-serializer-ansi:.*'))
+        include(dependency('co.aikar:acf-paper:.*'))
+        include(dependency('org.reflections:.*'))
+        include(dependency('org.javassist:.*'))
+        include(dependency('dev.triumphteam:triumph-gui:.*'))
     }
 
     final String group = project.group.toString() + "." + parent.name.toLowerCase() + ".shaded."
+    relocate 'com.fasterxml.jackson', 'com.emmerichbrowne.duels.shaded.jackson'
     relocate 'space.arim.morepaperlib', group + 'morepaperlib'
+    relocate 'com.mongodb', group + 'mongodb'
+    relocate 'org.bson', group + 'bson'
+    relocate 'redis.clients', group + 'redis'
+    relocate 'org.apache.commons.pool2', group + 'commons.pool2'
+    relocate 'org.apache.commons.lang3', group + 'commons.lang3'
+    relocate 'co.aikar.commands', group + 'acf'
+    relocate 'co.aikar.locales', group + 'acflocales'
+    relocate 'org.reflections', group + 'reflections'
+    relocate 'javassist', group + 'javassist'
+    relocate 'com.google.inject', group + 'guice'
+    relocate 'dev.triumphteam.gui', group + 'triumph.gui'
+
+    // Avoid including any plugin descriptors from dependency modules
+    exclude('paper-plugin.yml')
 }
 
 build {

--- a/duels-game-plugin/build.gradle
+++ b/duels-game-plugin/build.gradle
@@ -10,6 +10,7 @@ processResources {
 
 dependencies {
     implementation project(':duels-api')
+    implementation project(':duels-core')
     implementation project(':duels-plugin')
 
     compileOnly 'org.projectlombok:lombok:1.18.38'

--- a/duels-game-plugin/build.gradle
+++ b/duels-game-plugin/build.gradle
@@ -1,0 +1,38 @@
+apply plugin: 'com.gradleup.shadow'
+
+processResources {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
+dependencies {
+    implementation project(':duels-api')
+
+    compileOnly 'org.projectlombok:lombok:1.18.38'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
+
+    implementation 'space.arim.morepaperlib:morepaperlib:0.4.4'
+}
+
+repositories {
+    mavenCentral()
+}
+
+shadowJar {
+    getDestinationDirectory().set(file("$rootDir/out/"))
+
+    final String archiveName = parent.name + '-' + project.version + '.jar'
+    getArchiveFileName().set(archiveName)
+
+    dependencies {
+        include(project(':duels-api'))
+        include(dependency('space.arim.morepaperlib:.*'))
+    }
+
+    final String group = project.group.toString() + "." + parent.name.toLowerCase() + ".shaded."
+    relocate 'space.arim.morepaperlib', group + 'morepaperlib'
+}
+
+build {
+    dependsOn(shadowJar)
+}
+

--- a/duels-game-plugin/src/main/java/com/emmerichbrowne/duels/game/DuelsGamePlugin.java
+++ b/duels-game-plugin/src/main/java/com/emmerichbrowne/duels/game/DuelsGamePlugin.java
@@ -1,16 +1,12 @@
 package com.emmerichbrowne.duels.game;
 
-import org.bukkit.plugin.java.JavaPlugin;
+import com.emmerichbrowne.duels.DuelsPlugin;
+import com.emmerichbrowne.duels.ServerRole;
 
-public final class DuelsGamePlugin extends JavaPlugin {
+public final class DuelsGamePlugin extends DuelsPlugin {
 	@Override
-	public void onEnable() {
-		getLogger().info("Duels Game Plugin enabled");
-	}
-
-	@Override
-	public void onDisable() {
-		getLogger().info("Duels Game Plugin disabled");
+	public ServerRole getServerRole() {
+		return ServerRole.GAME;
 	}
 }
 

--- a/duels-game-plugin/src/main/java/com/emmerichbrowne/duels/game/DuelsGamePlugin.java
+++ b/duels-game-plugin/src/main/java/com/emmerichbrowne/duels/game/DuelsGamePlugin.java
@@ -1,0 +1,16 @@
+package com.emmerichbrowne.duels.game;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public final class DuelsGamePlugin extends JavaPlugin {
+	@Override
+	public void onEnable() {
+		getLogger().info("Duels Game Plugin enabled");
+	}
+
+	@Override
+	public void onDisable() {
+		getLogger().info("Duels Game Plugin disabled");
+	}
+}
+

--- a/duels-game-plugin/src/main/java/com/emmerichbrowne/duels/game/DuelsGamePlugin.java
+++ b/duels-game-plugin/src/main/java/com/emmerichbrowne/duels/game/DuelsGamePlugin.java
@@ -1,12 +1,11 @@
 package com.emmerichbrowne.duels.game;
 
 import com.emmerichbrowne.duels.DuelsPlugin;
-import com.emmerichbrowne.duels.ServerRole;
 
 public final class DuelsGamePlugin extends DuelsPlugin {
 	@Override
-	public ServerRole getServerRole() {
-		return ServerRole.GAME;
+	public com.emmerichbrowne.duels.core.ServerRole getServerRole() {
+		return com.emmerichbrowne.duels.core.ServerRole.GAME;
 	}
 }
 

--- a/duels-game-plugin/src/main/resources/paper-plugin.yml
+++ b/duels-game-plugin/src/main/resources/paper-plugin.yml
@@ -1,0 +1,15 @@
+name: Duels-Game
+main: com.emmerichbrowne.duels.game.DuelsGamePlugin
+version: @VERSION@
+api-version: 1.21.4
+folia-supported: true
+
+author: Emmerich
+website: https://github.com/emmerichdev/Duels
+description: The duels game plugin for Minatra
+
+dependencies:
+  server:
+    ASPaperPlugin:
+      required: true
+

--- a/duels-plugin/build.gradle
+++ b/duels-plugin/build.gradle
@@ -59,7 +59,7 @@ repositories {
 shadowJar {
 	getDestinationDirectory().set(file("$rootDir/out/"))
 
-	final String archiveName = parent.name + '-' + project.version + '.jar'
+	final String archiveName = 'Duels-Lobby-' + project.version + '.jar'
 	getArchiveFileName().set(archiveName)
 
 	dependencies {

--- a/duels-plugin/build.gradle
+++ b/duels-plugin/build.gradle
@@ -17,6 +17,7 @@ processResources {
 
 dependencies {
 	implementation project(':duels-api')
+	implementation project(':duels-core')
 	
 	compileOnly 'org.projectlombok:lombok:1.18.38'
 	annotationProcessor 'org.projectlombok:lombok:1.18.38'

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/DuelsPlugin.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/DuelsPlugin.java
@@ -322,8 +322,8 @@ public class DuelsPlugin extends JavaPlugin implements Duels, LogSource {
         return CC.translateConsole("&b&lDuels &7» ");
     }
 
-    public ServerRole getServerRole() {
-        return ServerRole.LOBBY;
+    public com.emmerichbrowne.duels.core.ServerRole getServerRole() {
+        return com.emmerichbrowne.duels.core.ServerRole.LOBBY;
     }
 
     public static void sendMessage(String message) {

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/DuelsPlugin.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/DuelsPlugin.java
@@ -322,6 +322,10 @@ public class DuelsPlugin extends JavaPlugin implements Duels, LogSource {
         return CC.translateConsole("&b&lDuels &7» ");
     }
 
+    public ServerRole getServerRole() {
+        return ServerRole.LOBBY;
+    }
+
     public static void sendMessage(String message) {
         final String prefix = getPrefix();
         if (message == null || message.isEmpty()) {

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/ServerRole.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/ServerRole.java
@@ -1,0 +1,7 @@
+package com.emmerichbrowne.duels;
+
+public enum ServerRole {
+	LOBBY,
+	GAME
+}
+

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/ServerRole.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/ServerRole.java
@@ -1,5 +1,6 @@
 package com.emmerichbrowne.duels;
 
+@Deprecated
 public enum ServerRole {
 	LOBBY,
 	GAME

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/arena/ArenaImpl.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/arena/ArenaImpl.java
@@ -218,7 +218,9 @@ public class ArenaImpl extends BaseButton implements Arena {
 
         if (source != null) {
             source.update();
-            queueManager.getGui().calculatePages();
+            if (queueManager != null && queueManager.getGui() != null) {
+                queueManager.getGui().calculatePages();
+            }
         }
 
         refreshGui(true);

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/commands/BaseCommand.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/commands/BaseCommand.java
@@ -5,56 +5,64 @@ import com.emmerichbrowne.duels.arena.ArenaManagerImpl;
 import com.emmerichbrowne.duels.betting.BettingManager;
 import com.emmerichbrowne.duels.config.Config;
 import com.emmerichbrowne.duels.config.Lang;
-import com.emmerichbrowne.duels.data.UserManagerImpl;
-import com.emmerichbrowne.duels.duel.DuelManager;
-import com.emmerichbrowne.duels.hook.HookManager;
 import com.emmerichbrowne.duels.inventories.InventoryManager;
 import com.emmerichbrowne.duels.kit.KitManagerImpl;
+import com.emmerichbrowne.duels.leaderboard.manager.LeaderboardManager;
 import com.emmerichbrowne.duels.party.PartyManagerImpl;
 import com.emmerichbrowne.duels.player.PlayerInfoManager;
 import com.emmerichbrowne.duels.queue.QueueManager;
 import com.emmerichbrowne.duels.queue.sign.QueueSignManagerImpl;
+import com.emmerichbrowne.duels.rank.manager.RankManager;
 import com.emmerichbrowne.duels.request.RequestManager;
 import com.emmerichbrowne.duels.setting.SettingsManager;
+import com.emmerichbrowne.duels.duel.DuelManager;
+import com.emmerichbrowne.duels.data.UserManagerImpl;
 import com.emmerichbrowne.duels.spectate.SpectateManagerImpl;
+import com.emmerichbrowne.duels.util.CC;
 
-public class BaseCommand extends co.aikar.commands.BaseCommand {
+public abstract class BaseCommand extends co.aikar.commands.BaseCommand {
 
     protected final DuelsPlugin plugin;
     protected final Config config;
     protected final Lang lang;
-    protected final UserManagerImpl userManager;
     protected final KitManagerImpl kitManager;
     protected final ArenaManagerImpl arenaManager;
+    protected final BettingManager bettingManager;
+    protected final SettingsManager settingManager;
     protected final QueueManager queueManager;
     protected final QueueSignManagerImpl queueSignManager;
-    protected final SettingsManager settingManager;
+    protected final RequestManager requestManager;
+    protected final PartyManagerImpl partyManager;
+    protected final LeaderboardManager leaderboardManager;
+    protected final RankManager rankManager;
+    protected final UserManagerImpl userManager;
     protected final PlayerInfoManager playerManager;
-    protected final SpectateManagerImpl spectateManager;
-    protected final BettingManager bettingManager;
     protected final InventoryManager inventoryManager;
     protected final DuelManager duelManager;
-    protected final RequestManager requestManager;
-    protected final HookManager hookManager;
-    protected final PartyManagerImpl partyManager;
+    protected final SpectateManagerImpl spectateManager;
 
-    public BaseCommand(DuelsPlugin plugin) {
+    public BaseCommand(final DuelsPlugin plugin) {
         this.plugin = plugin;
         this.config = plugin.getConfiguration();
         this.lang = plugin.getLang();
-        this.userManager = plugin.getUserManager();
-        this.partyManager = plugin.getPartyManager();
         this.kitManager = plugin.getKitManager();
         this.arenaManager = plugin.getArenaManager();
-        this.queueManager = plugin.getQueueManager();
-        this.queueSignManager = plugin.getQueueSignManager();
-        this.settingManager = plugin.getSettingManager();
-        this.playerManager = plugin.getPlayerManager();
-        this.spectateManager = plugin.getSpectateManager();
         this.bettingManager = plugin.getBettingManager();
+        this.settingManager = plugin.getSettingManager();
+        this.queueManager = plugin.getServerRole() == com.emmerichbrowne.duels.ServerRole.LOBBY ? plugin.getQueueManager() : null;
+        this.queueSignManager = plugin.getServerRole() == com.emmerichbrowne.duels.ServerRole.LOBBY ? plugin.getQueueSignManager() : null;
+        this.requestManager = plugin.getRequestManager();
+        this.partyManager = plugin.getPartyManager();
+        this.leaderboardManager = plugin.getLeaderboardManager();
+        this.rankManager = plugin.getRankManager();
+        this.userManager = plugin.getUserManager();
+        this.playerManager = plugin.getPlayerManager();
         this.inventoryManager = plugin.getInventoryManager();
         this.duelManager = plugin.getDuelManager();
-        this.requestManager = plugin.getRequestManager();
-        this.hookManager = plugin.getHookManager();
+        this.spectateManager = plugin.getSpectateManager();
+    }
+
+    protected String getPrefix() {
+        return CC.translateConsole("&b&lDuels &7» ");
     }
 }

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/commands/BaseCommand.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/commands/BaseCommand.java
@@ -49,8 +49,8 @@ public abstract class BaseCommand extends co.aikar.commands.BaseCommand {
         this.arenaManager = plugin.getArenaManager();
         this.bettingManager = plugin.getBettingManager();
         this.settingManager = plugin.getSettingManager();
-        this.queueManager = plugin.getServerRole() == com.emmerichbrowne.duels.ServerRole.LOBBY ? plugin.getQueueManager() : null;
-        this.queueSignManager = plugin.getServerRole() == com.emmerichbrowne.duels.ServerRole.LOBBY ? plugin.getQueueSignManager() : null;
+        this.queueManager = plugin.getServerRole() == com.emmerichbrowne.duels.core.ServerRole.LOBBY ? plugin.getQueueManager() : null;
+        this.queueSignManager = plugin.getServerRole() == com.emmerichbrowne.duels.core.ServerRole.LOBBY ? plugin.getQueueSignManager() : null;
         this.requestManager = plugin.getRequestManager();
         this.partyManager = plugin.getPartyManager();
         this.leaderboardManager = plugin.getLeaderboardManager();

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/commands/DuelsCommand.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/commands/DuelsCommand.java
@@ -86,8 +86,8 @@ public class DuelsCommand extends BaseCommand {
         final List<String> arenas = new ArrayList<>();
         arenaManager.getArenasImpl().forEach(arena -> arenas.add("&" + getColor(arena) + arena.getName()));
         final String kits = StringUtil.join(kitManager.getKits().stream().map(Kit::getName).collect(Collectors.toList()), ", ");
-        final String queues = StringUtil.join(queueManager.getQueues().stream().map(DQueue::toString).collect(Collectors.toList()), ", ");
-        final String signs = StringUtil.join(queueSignManager.getSigns().stream().map(QueueSignImpl::toString).collect(Collectors.toList()), ", ");
+        final String queues = (queueManager != null) ? StringUtil.join(queueManager.getQueues().stream().map(DQueue::toString).collect(Collectors.toList()), ", ") : lang.getMessage("GENERAL.none");
+        final String signs = (queueSignManager != null) ? StringUtil.join(queueSignManager.getSigns().stream().map(QueueSignImpl::toString).collect(Collectors.toList()), ", ") : lang.getMessage("GENERAL.none");
         lang.sendMessage(sender, "COMMAND.duels.list",
                 "arenas", !arenas.isEmpty() ? StringUtil.join(arenas, "&r, &r") : lang.getMessage("GENERAL.none"),
                 "kits", !kits.isEmpty() ? kits : lang.getMessage("GENERAL.none"),

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/duel/DuelManager.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/duel/DuelManager.java
@@ -393,7 +393,7 @@ public class DuelManager implements Loadable {
 
     private void addPlayers(final Collection<Player> players, final DuelMatch match, final ArenaImpl arena, final KitImpl kit, final Location location) {
         for (final Player player : players) {
-            if (match.getSource() == null) {
+            if (match.getSource() == null && queueManager != null) {
                 queueManager.remove(player);
             }
 

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/hook/HookManager.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/hook/HookManager.java
@@ -7,6 +7,7 @@ import com.emmerichbrowne.duels.hook.hooks.PlaceholderHook;
 import com.emmerichbrowne.duels.hook.hooks.VaultHook;
 import com.emmerichbrowne.duels.hook.hooks.worldguard.WorldGuardHook;
 import com.emmerichbrowne.duels.util.hook.AbstractHookManager;
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
 
 public class HookManager extends AbstractHookManager<DuelsPlugin> {
 
@@ -14,7 +15,10 @@ public class HookManager extends AbstractHookManager<DuelsPlugin> {
         super(plugin);
         register(DeluxeCombatHook.NAME, DeluxeCombatHook.class);
         register(EssentialsHook.NAME, EssentialsHook.class);
-        register(PlaceholderHook.NAME, PlaceholderHook.class);
+        // PlaceholderAPI is a special case; register expansion if present
+        if (plugin.getServer().getPluginManager().getPlugin(PlaceholderHook.NAME) instanceof PlaceholderAPIPlugin) {
+            new PlaceholderHook(plugin).register();
+        }
         register(VaultHook.NAME, VaultHook.class);
         register(WorldGuardHook.NAME, WorldGuardHook.class);
     }

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/hook/hooks/PlaceholderHook.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/hook/hooks/PlaceholderHook.java
@@ -55,7 +55,7 @@ public class PlaceholderHook extends PlaceholderExpansion {
     }
 
     private String handleQueue(String[] args) {
-        if (plugin.getServerRole() != com.emmerichbrowne.duels.ServerRole.LOBBY) {
+        if (plugin.getServerRole() != com.emmerichbrowne.duels.core.ServerRole.LOBBY) {
             return "0";
         }
         if (args.length < 2) return null;

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/hook/hooks/PlaceholderHook.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/hook/hooks/PlaceholderHook.java
@@ -1,351 +1,74 @@
 package com.emmerichbrowne.duels.hook.hooks;
 
 import com.emmerichbrowne.duels.DuelsPlugin;
-import com.emmerichbrowne.duels.api.arena.Arena;
 import com.emmerichbrowne.duels.api.kit.Kit;
-import com.emmerichbrowne.duels.api.match.Match;
-import com.emmerichbrowne.duels.api.spectate.Spectator;
-import com.emmerichbrowne.duels.api.user.User;
-import com.emmerichbrowne.duels.leaderboard.LeaderboardEntry;
-import com.emmerichbrowne.duels.rank.Rank;
-import com.emmerichbrowne.duels.util.CC;
-
-import com.emmerichbrowne.duels.util.hook.PluginHook;
+import com.emmerichbrowne.duels.api.queue.DQueue;
+import com.emmerichbrowne.duels.config.Config;
+import com.emmerichbrowne.duels.hook.HookManager;
+import com.emmerichbrowne.duels.queue.Queue;
+import com.emmerichbrowne.duels.util.Log;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-public class PlaceholderHook extends PluginHook<DuelsPlugin> {
+import java.util.List;
+
+public class PlaceholderHook extends PlaceholderExpansion {
 
     public static final String NAME = "PlaceholderAPI";
 
+    private final DuelsPlugin plugin;
+
     public PlaceholderHook(final DuelsPlugin plugin) {
-        super(plugin, NAME);
-        new Placeholders().register();
+        this.plugin = plugin;
     }
 
-    public class Placeholders extends PlaceholderExpansion {
-        @Override
-        public @NotNull String getIdentifier() {
-            return "duels";
-        }
+    @Override
+    public @NotNull String getIdentifier() {
+        return "duels";
+    }
 
-        @Override
-        public @NotNull String getAuthor() {
-            return "DUMBO, Emmerich";
-        }
+    @Override
+    public @NotNull String getAuthor() {
+        return String.join(", ", plugin.getPluginMeta().getAuthors());
+    }
 
-        @Override
-        public @NotNull String getVersion() {
-            return "5.0";
-        }
+    @Override
+    public @NotNull String getVersion() {
+        return plugin.getVersion();
+    }
 
-        @Override
-        public boolean persist() {
-            return true;
-        }
+    @Override
+    public String onRequest(OfflinePlayer player, @NotNull String params) {
+        try {
+            final String[] args = params.split("_");
+            if (args.length == 0) return null;
 
-        @Override
-        public @Nullable String onPlaceholderRequest(@Nullable Player player, @NotNull String identifier) {
-            if (player == null) {
-                return "Player is required";
-            }
-
-            User user;
-            switch (identifier) {
-                case "wins":
-                    user = plugin.getUserManager().get(player);
-
-                    if (user == null) {
-                        return CC.translate(plugin.getConfiguration().getUserNotFound());
-                    }
-                    return String.valueOf(user.getWins());
-                case "losses":
-                    user = plugin.getUserManager().get(player);
-                    if (user == null) {
-                        return CC.translate(plugin.getConfiguration().getUserNotFound());
-                    }
-                    return String.valueOf(user.getLosses());
-                case "can_request":
-                    user = plugin.getUserManager().get(player);
-                    if (user == null) {
-                        return CC.translate(plugin.getConfiguration().getUserNotFound());
-                    }
-                    return String.valueOf(user.canRequest());
-
-                case "wl_ratio":
-                case "wlr":
-                    user = plugin.getUserManager().get(player);
-                    if (user == null) {
-                        return CC.translate(plugin.getConfiguration().getUserNotFound());
-                    }
-                    int wins = user.getWins();
-                    int losses = user.getLosses();
-                    return String.valueOf(wlr(wins, losses));
-            }
-
-            if (identifier.startsWith("rating_")) {
-                user = plugin.getUserManager().get(player);
-
-                if (user == null) {
-                    return CC.translate(plugin.getConfiguration().getUserNotFound());
-                }
-
-                identifier = identifier.replace("rating_", "");
-
-                if (identifier.equals("-")) {
-                    return String.valueOf(user.getRating());
-                }
-
-                final Kit kit = plugin.getKitManager().get(identifier);
-                return kit != null ? String.valueOf(user.getRating(kit)) : CC.translate(plugin.getConfiguration().getNoKit());
-            }
-
-            // Total ELO placeholder
-            if (identifier.equals("total_elo")) {
-                user = plugin.getUserManager().get(player);
-
-                if (user == null) {
-                    return CC.translate(plugin.getConfiguration().getUserNotFound());
-                }
-
-                return String.valueOf(user.getTotalElo());
-            }
-
-            // ELO by kit placeholders: %duels_elo_<kitname>%
-            if (identifier.startsWith("elo_")) {
-                user = plugin.getUserManager().get(player);
-
-                if (user == null) {
-                    return CC.translate(plugin.getConfiguration().getUserNotFound());
-                }
-
-                identifier = identifier.replace("elo_", "");
-
-                final Kit kit = plugin.getKitManager().get(identifier);
-                return kit != null ? String.valueOf(user.getRating(kit)) : CC.translate(plugin.getConfiguration().getNoKit());
-            }
-
-            // ELO leaderboard placeholders: %duels_elo_leaderboard_<position>%
-            if (identifier.startsWith("elo_leaderboard_")) {
-                String positionStr = identifier.replace("elo_leaderboard_", "");
-                try {
-                    int position = Integer.parseInt(positionStr);
-                    if (position < 1 || position > 10) {
-                        return "Invalid position";
-                    }
-                    
-                    LeaderboardEntry entry = plugin.getLeaderboardManager().getTotalEloEntry(position);
-                    return entry != null ? entry.playerName() : "N/A";
-                } catch (NumberFormatException e) {
-                    return "Invalid position";
-                }
-            }
-
-            // Rank placeholders
-            switch (identifier) {
-                case "rank_name" -> {
-                    if (!plugin.getRankManager().isEnabled()) {
-                        return "Rank system disabled";
-                    }
-
-                    Rank rank = plugin.getRankManager().getPlayerRank(player);
-                    return rank != null ? rank.getColoredName() : "Unknown";
-                }
-                case "rank_desc" -> {
-                    if (!plugin.getRankManager().isEnabled()) {
-                        return "Rank system disabled";
-                    }
-
-                    Rank rank = plugin.getRankManager().getPlayerRank(player);
-                    return rank != null ? rank.getDescription() : "No description";
-                }
-                case "rank_color" -> {
-                    if (!plugin.getRankManager().isEnabled()) {
-                        return "&7";
-                    }
-
-                    Rank rank = plugin.getRankManager().getPlayerRank(player);
-                    return rank != null ? rank.getColor() : "&7";
-                }
-                case "rank_progress" -> {
-                    if (!plugin.getRankManager().isEnabled()) {
-                        return "0";
-                    }
-
-                    Rank rank = plugin.getRankManager().getPlayerRank(player);
-                    if (rank == null) {
-                        return "0";
-                    }
-
-                    user = plugin.getUserManager().get(player);
-                    if (user == null) {
-                        return "0";
-                    }
-
-                    double progress = rank.getProgress(user.getTotalElo());
-                    return String.format("%.1f", progress);
-                }
-            }
-
-            if (identifier.startsWith("getplayersinqueue_")){
-                String kitName = identifier.replace("getplayersinqueue_", "");
-                String queueResult = handleQueuePlaceholder(player, kitName, true);
-                if (queueResult != null) return queueResult;
-            }
-
-            if (identifier.startsWith("getplayersplayinginqueue_")){
-                String kitName = identifier.replace("getplayersplayinginqueue_", "");
-                String queueResult = handleQueuePlaceholder(player, kitName, false);
-                if (queueResult != null) return queueResult;
-            }
-
-            if (identifier.startsWith("match_")) {
-                identifier = identifier.replace("match_", "");
-                Arena arena = plugin.getArenaManager().get(player);
-
-                if (arena == null) {
-                    final Spectator spectator = plugin.getSpectateManager().get(player);
-
-                    if (spectator == null) {
-                        return CC.translate(plugin.getConfiguration().getNotInMatch());
-                    }
-
-                    arena = spectator.getArena();
-                    player = spectator.getTarget();
-
-                    if (player == null) {
-                        return CC.translate(plugin.getConfiguration().getNotInMatch());
-                    }
-                }
-
-                final Match match = arena.getMatch();
-
-                if (match == null) {
-                    return CC.translate(plugin.getConfiguration().getNotInMatch());
-                }
-
-                if (identifier.equalsIgnoreCase("duration")) {
-                    return formatDuration(System.currentTimeMillis() - match.getStart(), plugin.getConfiguration().getDurationFormat());
-                }
-
-                if (identifier.equalsIgnoreCase("kit")) {
-                    return match.getKit() != null ? match.getKit().getName() : CC.translate(plugin.getConfiguration().getNoKit());
-                }
-
-                if (identifier.equalsIgnoreCase("arena")) {
-                    return match.getArena().getName();
-                }
-
-                if (identifier.equalsIgnoreCase("bet")) {
-                    return String.valueOf(match.getBet());
-                }
-
-                if (identifier.equalsIgnoreCase("rating")) {
-                    user = plugin.getUserManager().get(player);
-
-                    if (user == null) {
-                        return CC.translate(plugin.getConfiguration().getUserNotFound());
-                    }
-
-                    return String.valueOf(match.getKit() != null ? user.getRating(match.getKit()) : user.getRating());
-                }
-
-                if (identifier.startsWith("opponent")) {
-                    Player opponent = null;
-
-                    for (final Player matchPlayer : match.getPlayers()) {
-                        if (!matchPlayer.equals(player)) {
-                            opponent = matchPlayer;
-                            break;
-                        }
-                    }
-
-                    if (opponent == null) {
-                        return CC.translate(plugin.getConfiguration().getNoOpponent());
-                    }
-
-                    if (identifier.equalsIgnoreCase("opponent")) {
-                        return opponent.getName();
-                    }
-
-                    if (identifier.endsWith("_health")) {
-                        return String.valueOf(Math.ceil(opponent.getHealth()) * 0.5);
-                    }
-
-                    if (identifier.endsWith("_ping")) {
-                        return String.valueOf(opponent.getPing());
-                    }
-
-                    user = plugin.getUserManager().get(opponent);
-
-                    if (user == null) {
-                        return CC.translate(plugin.getConfiguration().getUserNotFound());
-                    }
-
-                    return String.valueOf(match.getKit() != null ? user.getRating(match.getKit()) : user.getRating());
-                }
-            }
+            return switch (args[0].toLowerCase()) {
+                case "queue" -> handleQueue(args);
+                default -> null;
+            };
+        } catch (Exception ex) {
+            Log.error("PlaceholderAPI request failed: " + params, ex);
             return null;
         }
+    }
 
-        private String handleQueuePlaceholder(Player player, String kitName, boolean isQueuedPlayers) {
-            User user = plugin.getUserManager().get(player);
-            if (user == null) {
-                return CC.translate(plugin.getConfiguration().getUserNotFound());
-            }
-
-            final Kit kit = plugin.getKitManager().get(kitName);
-            if (kit == null) {
-                return CC.translate(plugin.getConfiguration().getNoKit());
-            }
-
-            var queue = plugin.getQueueManager().get(kit, 0);
-            if (queue == null) {
-                return "0";
-            }
-
-            if (isQueuedPlayers) {
-                int queuedPlayers = queue.getQueuedPlayers().size();
-                return queuedPlayers > 0 ? String.valueOf(queuedPlayers) : "0";
-            } else {
-                long playersInMatch = queue.getPlayersInMatch();
-                return Long.toString(playersInMatch);
-            }
+    private String handleQueue(String[] args) {
+        if (plugin.getServerRole() != com.emmerichbrowne.duels.ServerRole.LOBBY) {
+            return "0";
         }
-
-        private float wlr(int wins, int losses) {
-            if (wins == 0) {
-                return losses == 0 ? 0.0F : (float)(-losses);
-            } else if (losses == 0) {
-                return (float)wins;
-            } else {
-                return (float)(wins / losses);
-            }
+        if (args.length < 2) return null;
+        // queue_<kit or ->_<bet>
+        final String kitParam = args[1];
+        final int bet = args.length >= 3 ? Integer.parseInt(args[2]) : 0;
+        final Kit kit = kitParam.equals("-") ? null : plugin.getKitManager().get(kitParam);
+        var queue = plugin.getQueueManager().get(kit, bet);
+        if (queue == null) {
+            plugin.getQueueManager().create(kit, bet);
+            queue = plugin.getQueueManager().get(kit, bet);
         }
-
-        private String formatDuration(long durationMillis, String pattern) {
-            long totalSeconds = durationMillis / 1000;
-            long hours = totalSeconds / 3600;
-            long minutes = (totalSeconds % 3600) / 60;
-            long seconds = totalSeconds % 60;
-
-            // Default pattern if null or empty
-            if (pattern == null || pattern.trim().isEmpty()) {
-                pattern = "H:mm:ss";
-            }
-
-            // Replace pattern tokens with actual values (literal replacements, longer tokens first)
-            String result = pattern;
-            result = result.replace("HH", String.format("%02d", hours));
-            result = result.replace("H", String.valueOf(hours));
-            result = result.replace("mm", String.format("%02d", minutes));
-            result = result.replace("m", String.valueOf(minutes));
-            result = result.replace("ss", String.format("%02d", seconds));
-            result = result.replace("s", String.valueOf(seconds));
-
-            return result;
-        }
+        if (queue == null) return "0";
+        return String.valueOf(queue.getQueuedPlayers().size());
     }
 }

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/menus/BaseButton.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/menus/BaseButton.java
@@ -56,8 +56,8 @@ public abstract class BaseButton {
 		this.kitManager = plugin.getKitManager();
 		this.arenaManager = plugin.getArenaManager();
 		this.settingManager = plugin.getSettingManager();
-		this.queueManager = plugin.getServerRole() == com.emmerichbrowne.duels.ServerRole.LOBBY ? plugin.getQueueManager() : null;
-		this.queueSignManager = plugin.getServerRole() == com.emmerichbrowne.duels.ServerRole.LOBBY ? plugin.getQueueSignManager() : null;
+		this.queueManager = plugin.getServerRole() == com.emmerichbrowne.duels.core.ServerRole.LOBBY ? plugin.getQueueManager() : null;
+		this.queueSignManager = plugin.getServerRole() == com.emmerichbrowne.duels.core.ServerRole.LOBBY ? plugin.getQueueSignManager() : null;
 		this.spectateManager = plugin.getSpectateManager();
 		this.requestManager = plugin.getRequestManager();
 	}

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/menus/BaseButton.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/menus/BaseButton.java
@@ -56,8 +56,8 @@ public abstract class BaseButton {
 		this.kitManager = plugin.getKitManager();
 		this.arenaManager = plugin.getArenaManager();
 		this.settingManager = plugin.getSettingManager();
-		this.queueManager = plugin.getQueueManager();
-		this.queueSignManager = plugin.getQueueSignManager();
+		this.queueManager = plugin.getServerRole() == com.emmerichbrowne.duels.ServerRole.LOBBY ? plugin.getQueueManager() : null;
+		this.queueSignManager = plugin.getServerRole() == com.emmerichbrowne.duels.ServerRole.LOBBY ? plugin.getQueueSignManager() : null;
 		this.spectateManager = plugin.getSpectateManager();
 		this.requestManager = plugin.getRequestManager();
 	}

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/queue/Queue.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/queue/Queue.java
@@ -55,13 +55,17 @@ public class Queue extends BaseButton implements DQueue {
     void addPlayer(final QueueEntry entry) {
         players.add(entry);
         update();
-        queueManager.getGui().calculatePages();
+        if (queueManager != null && queueManager.getGui() != null) {
+            queueManager.getGui().calculatePages();
+        }
     }
 
     boolean removePlayer(final Player player) {
         if (players.removeIf(entry -> entry.getPlayer().equals(player))) {
             update();
-            queueManager.getGui().calculatePages();
+            if (queueManager != null && queueManager.getGui() != null) {
+                queueManager.getGui().calculatePages();
+            }
             return true;
         }
 
@@ -93,7 +97,9 @@ public class Queue extends BaseButton implements DQueue {
 
     @Override
     public void onClick(final Player player) {
-        queueManager.addToQueue(player, this);
+        if (queueManager != null) {
+            queueManager.addToQueue(player, this);
+        }
     }
 
     @Override

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/scanner/AutoRegistrationScanner.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/scanner/AutoRegistrationScanner.java
@@ -2,7 +2,7 @@ package com.emmerichbrowne.duels.scanner;
 
 import co.aikar.commands.PaperCommandManager;
 import com.emmerichbrowne.duels.DuelsPlugin;
-import com.emmerichbrowne.duels.ServerRole;
+import com.emmerichbrowne.duels.core.ServerRole;
 import com.emmerichbrowne.duels.commands.BaseCommand;
 import org.bukkit.event.Listener;
 import org.reflections.Reflections;

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/scanner/AutoRegistrationScanner.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/scanner/AutoRegistrationScanner.java
@@ -2,6 +2,7 @@ package com.emmerichbrowne.duels.scanner;
 
 import co.aikar.commands.PaperCommandManager;
 import com.emmerichbrowne.duels.DuelsPlugin;
+import com.emmerichbrowne.duels.ServerRole;
 import com.emmerichbrowne.duels.commands.BaseCommand;
 import org.bukkit.event.Listener;
 import org.reflections.Reflections;
@@ -27,6 +28,9 @@ public class AutoRegistrationScanner {
         
         for (Class<?> clazz : annotatedClasses) {
             try {
+                if (shouldSkipCommand(clazz)) {
+                    continue;
+                }
                 registerCommand(clazz);
             } catch (Exception e) {
                 plugin.getLogger().severe("Failed to register command " + clazz.getSimpleName() + ": " + e.getMessage());
@@ -61,6 +65,14 @@ public class AutoRegistrationScanner {
         
         commandManager.registerCommand(command);
         plugin.getLogger().info("Auto-registered command: " + clazz.getSimpleName());
+    }
+
+    private boolean shouldSkipCommand(Class<?> clazz) {
+        if (plugin.getServerRole() != ServerRole.GAME) {
+            return false;
+        }
+        final String simple = clazz.getSimpleName();
+        return simple.equals("QueueCommand") || simple.equals("QueueAdminCommand");
     }
     
     private void registerListener(Class<?> clazz) throws Exception {

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/spectate/SpectateManagerImpl.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/spectate/SpectateManagerImpl.java
@@ -104,7 +104,7 @@ public class SpectateManagerImpl implements Loadable, SpectateManager {
             return Result.ALREADY_SPECTATING;
         }
 
-        if (plugin.getQueueManager().isInQueue(player)) {
+        if (plugin.getServerRole() == com.emmerichbrowne.duels.ServerRole.LOBBY && plugin.getQueueManager().isInQueue(player)) {
             return Result.IN_QUEUE;
         }
 

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/spectate/SpectateManagerImpl.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/spectate/SpectateManagerImpl.java
@@ -104,7 +104,7 @@ public class SpectateManagerImpl implements Loadable, SpectateManager {
             return Result.ALREADY_SPECTATING;
         }
 
-        if (plugin.getServerRole() == com.emmerichbrowne.duels.ServerRole.LOBBY && plugin.getQueueManager().isInQueue(player)) {
+        if (plugin.getServerRole() == com.emmerichbrowne.duels.core.ServerRole.LOBBY && plugin.getQueueManager().isInQueue(player)) {
             return Result.IN_QUEUE;
         }
 

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/startup/LoadableManager.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/startup/LoadableManager.java
@@ -3,7 +3,7 @@ package com.emmerichbrowne.duels.startup;
 import com.google.common.collect.Lists;
 import com.emmerichbrowne.duels.DuelsPlugin;
 import com.emmerichbrowne.duels.arena.ArenaManagerImpl;
-import com.emmerichbrowne.duels.ServerRole;
+import com.emmerichbrowne.duels.core.ServerRole;
 import com.emmerichbrowne.duels.betting.BettingManager;
 import com.emmerichbrowne.duels.data.UserManagerImpl;
 import com.emmerichbrowne.duels.duel.DuelManager;

--- a/duels-plugin/src/main/java/com/emmerichbrowne/duels/startup/LoadableManager.java
+++ b/duels-plugin/src/main/java/com/emmerichbrowne/duels/startup/LoadableManager.java
@@ -3,6 +3,7 @@ package com.emmerichbrowne.duels.startup;
 import com.google.common.collect.Lists;
 import com.emmerichbrowne.duels.DuelsPlugin;
 import com.emmerichbrowne.duels.arena.ArenaManagerImpl;
+import com.emmerichbrowne.duels.ServerRole;
 import com.emmerichbrowne.duels.betting.BettingManager;
 import com.emmerichbrowne.duels.data.UserManagerImpl;
 import com.emmerichbrowne.duels.duel.DuelManager;
@@ -50,6 +51,7 @@ public class LoadableManager {
         
         // Initialize remaining loadables (Config and Lang are already initialized)
         // Skip config and lang as they are initialized earlier in the startup process
+        final ServerRole role = plugin.getServerRole();
         addLoadable("user manager", () -> {
             UserManagerImpl userManager = new UserManagerImpl(plugin);
             plugin.setUserManager(userManager);
@@ -100,21 +102,23 @@ public class LoadableManager {
             plugin.setDuelManager(duelManager);
             return duelManager;
         });
-        addLoadable("queue manager", () -> {
-            QueueManager queueManager = new QueueManager(plugin);
-            plugin.setQueueManager(queueManager);
-            return queueManager;
-        });
-        addLoadable("queue signs", () -> {
-            QueueSignManagerImpl queueSignManager = new QueueSignManagerImpl(plugin);
-            plugin.setQueueSignManager(queueSignManager);
-            return queueSignManager;
-        });
-        addLoadable("request manager", () -> {
-            RequestManager requestManager = new RequestManager(plugin);
-            plugin.setRequestManager(requestManager);
-            return requestManager;
-        });
+        if (role == ServerRole.LOBBY) {
+            addLoadable("queue manager", () -> {
+                QueueManager queueManager = new QueueManager(plugin);
+                plugin.setQueueManager(queueManager);
+                return queueManager;
+            });
+            addLoadable("queue signs", () -> {
+                QueueSignManagerImpl queueSignManager = new QueueSignManagerImpl(plugin);
+                plugin.setQueueSignManager(queueSignManager);
+                return queueSignManager;
+            });
+            addLoadable("request manager", () -> {
+                RequestManager requestManager = new RequestManager(plugin);
+                plugin.setRequestManager(requestManager);
+                return requestManager;
+            });
+        }
         addLoadable("leaderboard manager", () -> {
             LeaderboardManager leaderboardManager = new LeaderboardManager(plugin);
             plugin.setLeaderboardManager(leaderboardManager);

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,4 @@ rootProject.name = 'Duels'
 
 include 'duels-api'
 include 'duels-plugin'
+include 'duels-game-plugin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'Duels'
 
 include 'duels-api'
+include 'duels-core'
 include 'duels-plugin'
 include 'duels-game-plugin'


### PR DESCRIPTION
Add `duels-game-plugin` submodule to begin separating game-specific logic for a future lobby/game server split.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2163144-078a-452f-810a-6b927b8e7689">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e2163144-078a-452f-810a-6b927b8e7689">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

